### PR TITLE
fix wrong return type for `as`

### DIFF
--- a/src/main/scala/com/tegonal/scala/commons/anyExtensions.scala
+++ b/src/main/scala/com/tegonal/scala/commons/anyExtensions.scala
@@ -44,15 +44,12 @@ extension [T](self: T) {
    * @return The receiver object cast to [[TSub]]
    * @since 0.1.0
    */
-  inline def as[TSub <: T]: T = ${ asImpl[TSub, T]('self) }
+  inline def as[TSub <: T]: TSub = ${ asImpl[TSub, T]('self) }
 }
 
 @nowarn
 private def asImpl[T, U >: T](x: Expr[U])(using Type[T], Type[U], Quotes): Expr[T] = {
   import quotes.reflect.TypeRepr
-
-  val sym = TypeRepr.of[T].typeSymbol
-  val code = Expr(x.show)
 
   emitWarningIfUnableToTypeCheckEntirely[T]
   val isPrimitive = Expr(Type.of[T] match {


### PR DESCRIPTION
looks like I forgot to rename the type variable when renaming T to TSub



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scala-commons/blob/v0.1.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
